### PR TITLE
Disable NOTICE and license-headers plugins for standalone submodule builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -724,6 +724,7 @@
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <version>2.2</version>
+                <inherited>false</inherited>
                 <configuration>
                     <header>misc/52N_license-header.txt</header>
                     <properties>
@@ -760,6 +761,7 @@
                 <groupId>org.jasig.maven</groupId>
                 <artifactId>maven-notice-plugin</artifactId>
                 <version>1.0.6</version>
+                <inherited>false</inherited>
                 <configuration>
                     <noticeTemplate>misc/NOTICE.template</noticeTemplate>
                     <licenseMapping>


### PR DESCRIPTION
what do you think, @ridoo ?
