### PR TITLE
Fix/harvesting ereporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1005,7 +1005,7 @@
         <jackson.version>2.2.2</jackson.version>
         <smartgwt.version>3.1</smartgwt.version>
         <geotools.version>8.5</geotools.version>
-        <oxf.version>2.0.0-alpha.3.3</oxf.version>
+        <oxf.version>2.0.0-alpha.3.4-SNAPSHOT</oxf.version>
         <hamcrest.version>1.3</hamcrest.version>
         <timeseries.api.version>1.2.1</timeseries.api.version>
         <hibernate.version>3.5.0-Final</hibernate.version>
@@ -1013,7 +1013,7 @@
         <org.springframework.version>3.2.0.RELEASE</org.springframework.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sensorwebclient.webapp.name>${project.artifactId}-${project.version}</sensorwebclient.webapp.name>
+        <sensorwebclient.webapp.name>sensorwebclient-webapp-${project.version}</sensorwebclient.webapp.name>
 
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>

--- a/sensorwebclient-api/src/main/java/org/n52/server/parser/GetFeatureOfInterestParser.java
+++ b/sensorwebclient-api/src/main/java/org/n52/server/parser/GetFeatureOfInterestParser.java
@@ -27,10 +27,11 @@
  */
 package org.n52.server.parser;
 
+import com.vividsolutions.jts.geom.Point;
 import java.io.IOException;
-
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.namespace.QName;
-
 import net.opengis.gml.x32.AbstractGeometryType;
 import net.opengis.gml.x32.DirectPositionType;
 import net.opengis.gml.x32.FeaturePropertyType;
@@ -41,7 +42,6 @@ import net.opengis.samplingSpatial.x20.ShapeDocument;
 import net.opengis.sos.x20.GetFeatureOfInterestResponseDocument;
 import net.opengis.waterml.x20.MonitoringPointDocument;
 import net.opengis.waterml.x20.MonitoringPointType;
-
 import org.apache.xmlbeans.XmlCursor;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlObject;
@@ -56,8 +56,6 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.operation.TransformException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.vividsolutions.jts.geom.Point;
 
 public class GetFeatureOfInterestParser {
 
@@ -80,9 +78,12 @@ public class GetFeatureOfInterestParser {
 		}
 	}
 
-	public void createFeatures() throws XmlException, IOException, OXFException {
-        GetFeatureOfInterestResponseDocument foiResDoc = getFOIResponseOfOpResult(getFoiResult);
+	public List<Station> createStations() throws XmlException, IOException, OXFException {
+
+        List<Station> stations = new ArrayList<Station>();
         TimeseriesParametersLookup lookup = metadata.getTimeseriesParametersLookup();
+        GetFeatureOfInterestResponseDocument foiResDoc = getFOIResponseOfOpResult(getFoiResult);
+
         String id = null;
         String label = null;
         for (FeaturePropertyType featurePropertyType : foiResDoc.getGetFeatureOfInterestResponse().getFeatureMemberArray()) {
@@ -131,9 +132,11 @@ public class GetFeatureOfInterestParser {
                     station = new Station(feature);
                     station.setLocation(point);
                     metadata.addStation(station);
+                    stations.add(station);
                 }
             }
         }
+        return stations;
 	}
 
 	private Point createParsedPoint(XmlObject feature, CRSUtils referenceHelper) throws XmlException {

--- a/sensorwebclient-hydro/src/main/java/org/n52/server/sos/connector/hydro/HydroMetadataHandler.java
+++ b/sensorwebclient-hydro/src/main/java/org/n52/server/sos/connector/hydro/HydroMetadataHandler.java
@@ -197,7 +197,7 @@ public class HydroMetadataHandler extends MetadataHandler {
             try {
                 OperationResult opRes = futureTask.get(metadata.getTimeout(), MILLISECONDS);
                 GetFeatureOfInterestParser getFoiParser = new GetFeatureOfInterestParser(opRes, metadata);
-                getFoiParser.createFeatures();
+                getFoiParser.createStations();
             }
             catch (TimeoutException e) {
                 LOGGER.error("Timeout occured.", e);

--- a/sensorwebclient-hydro/src/main/java/org/n52/server/sos/connector/hydro/PhenomenonFilteredHydroMetadataHandler.java
+++ b/sensorwebclient-hydro/src/main/java/org/n52/server/sos/connector/hydro/PhenomenonFilteredHydroMetadataHandler.java
@@ -237,7 +237,7 @@ public class PhenomenonFilteredHydroMetadataHandler extends HydroMetadataHandler
             try {
                 OperationResult opsRes = futureTask.get(SERVER_TIMEOUT, MILLISECONDS);
                 GetFeatureOfInterestParser getFoiParser = new GetFeatureOfInterestParser(opsRes, metadata);
-                getFoiParser.createFeatures();
+                getFoiParser.createStations();
             }
             catch (TimeoutException e) {
                 LOGGER.error("Timeout occured.", e);


### PR DESCRIPTION
Harvesting an e-reporting profiled SOS (not SOE) was buggy. Fix contains a slightly different logic in interlinking parameters to timeseries. Needs an update of the OX-F maintenance branch for the SWC.